### PR TITLE
fix astyle to only run in project folder

### DIFF
--- a/tools/astyle.sh
+++ b/tools/astyle.sh
@@ -1,1 +1,1 @@
-astyle --style=allman --recursive --suffix=none /../*.c,*.h
+astyle --style=allman --recursive --suffix=none ../../rainbow/*.c,*.h


### PR DESCRIPTION
astyle was running on projects in the same work folder. fixed to only run within rainbow project.